### PR TITLE
インプットコンポーネントの暫定的な完成

### DIFF
--- a/frontend/src/components/utils/imagePreview.tsx
+++ b/frontend/src/components/utils/imagePreview.tsx
@@ -1,5 +1,4 @@
 import NextImage from 'next/image';
-// import { useEffect, useState } from 'react';
 
 interface ImagePreviewProps {
   image: string | undefined;

--- a/frontend/src/components/utils/imagePreview.tsx
+++ b/frontend/src/components/utils/imagePreview.tsx
@@ -1,0 +1,42 @@
+import NextImage from 'next/image';
+// import { useEffect, useState } from 'react';
+
+interface ImagePreviewProps {
+  image: string | undefined;
+  alt?: string;
+  maxWidth?: number;
+  maxHeight?: number;
+}
+
+export const ImagePreview: React.FC<ImagePreviewProps> = ({
+  image,
+  alt = 'preview',
+  maxWidth = 400,
+}) => {
+  return (
+    <div
+      style={{ maxWidth: `${maxWidth}px`, width: '100%', overflow: 'hidden' }}
+    >
+      <div style={{ paddingTop: '100%', position: 'relative' }}>
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            bottom: 0,
+            right: 0,
+          }}
+        >
+          {image && (
+            <NextImage
+              src={image}
+              alt={alt}
+              layout='fill'
+              objectFit='contain'
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/utils/input.tsx
+++ b/frontend/src/components/utils/input.tsx
@@ -1,0 +1,186 @@
+import RawTextField from '@mui/material/TextField';
+import Image1 from 'next/image';
+import { useState } from 'react';
+
+interface TextFieldProps {
+  hidden?: boolean;
+  autoComplete?: string;
+  autoFocus?: boolean;
+  color?: 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
+  defaultvalue?: string;
+  disabled?: boolean;
+  error?: boolean;
+  fullWidth?: boolean;
+  height?: string;
+  id?: string;
+  label?: string;
+  maxRows?: number;
+  multiline?: boolean;
+  placehodler?: string;
+  readOnly?: boolean;
+  shrink?: boolean;
+  type?: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  value?: string;
+  width?: string;
+}
+
+export const TextField: React.FC<TextFieldProps> = ({
+  hidden = false,
+  autoComplete = 'off',
+  // autoFocus = false,
+  color = 'secondary',
+  defaultvalue,
+  disabled = false,
+  error = false,
+  fullWidth = false,
+  height,
+  id = '',
+  label = '',
+  placehodler = '',
+  multiline = false,
+  maxRows = 10,
+  readOnly = false,
+  shrink = true,
+  type = 'text',
+  onChange,
+  value,
+  width,
+}) => {
+  const [isShrunk, setIsShrunk] = useState(shrink);
+  const [isFocused, setIsFocused] = useState(false);
+  const [isBlank, setIsBlank] = useState(!defaultvalue);
+  const onFocus = () => {
+    setIsShrunk(true);
+    setIsFocused(true);
+  };
+  const onBlur = () => {
+    setIsFocused(false);
+    if (!shrink && isBlank) {
+      setIsShrunk(false);
+    }
+  };
+  const onMouseOver = () => {
+    setIsShrunk(true);
+  };
+  const onMouseLeave = () => {
+    if (!isFocused && isBlank) {
+      setIsShrunk(false);
+    }
+  };
+  const _onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setIsBlank(!e.target.value.length);
+    onChange(e);
+  };
+  const sxprops = {
+    margin: '8px',
+    // height: height,
+    width: width,
+  };
+  return (
+    <RawTextField
+      hidden={hidden}
+      autoComplete={autoComplete}
+      // autoFocus={autoFocus}
+      color={color}
+      defaultValue={defaultvalue}
+      disabled={disabled}
+      error={error}
+      fullWidth={fullWidth}
+      label={label}
+      sx={sxprops}
+      placeholder={placehodler}
+      multiline={multiline}
+      maxRows={maxRows}
+      // readOnly={readOnly}
+      type={type}
+      InputLabelProps={{
+        shrink: isShrunk,
+      }}
+      id={id}
+      InputProps={{ sx: { height: height } }}
+      inputProps={{ readOnly: readOnly }}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onMouseOver={onMouseOver}
+      onMouseLeave={onMouseLeave}
+      onChange={(e) => {
+        _onChange(e as React.ChangeEvent<HTMLInputElement>);
+      }}
+      value={value}
+    ></RawTextField>
+  );
+};
+
+interface ImageInputProps {
+  alt?: string;
+  maxwidth?: number;
+  id: string;
+}
+
+export const ImageInput: React.FC<ImageInputProps> = ({
+  alt = '画像プレビュー',
+  maxwidth = 300,
+  id,
+}) => {
+  //event handler start
+  const [imagePreview, setImagePreview] = useState<
+    string | ArrayBuffer | null | undefined
+  >(undefined);
+  const [heightPixel, setHeightPixel] = useState(0);
+  const [widthPixel, setWidthPixel] = useState(0);
+  const onChangeFileInput = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    setImagePreview(undefined);
+    if (event.target.files?.length === 0) {
+      return;
+    }
+    if (event.target.files?.[0] === undefined) {
+      return;
+    }
+    if (!event.target.files?.[0].type.match('image.*')) {
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      setImagePreview(e.target?.result);
+      const image = new Image();
+      image.src = e.target?.result as string;
+      image.onload = () => {
+        const originalWidth = image.width as number;
+        const originalHeight = image.height as number;
+        //画像のサイズに関する制限などはここに書けばよさそう
+        if (originalWidth > originalHeight) {
+          setWidthPixel(maxwidth);
+          setHeightPixel((maxwidth * originalHeight) / originalWidth);
+        } else {
+          setHeightPixel(maxwidth);
+          setWidthPixel((maxwidth * originalWidth) / originalHeight);
+        }
+      };
+    };
+
+    reader.readAsDataURL(event.target?.files[0]);
+  };
+  //event handler end
+  return (
+    <>
+      <input
+        type='file'
+        accept='image/*'
+        id={id}
+        onChange={onChangeFileInput}
+        hidden={true}
+      />
+      <output>
+        <Image1
+          src={imagePreview as string}
+          alt={alt}
+          width={widthPixel}
+          height={heightPixel}
+        />
+      </output>
+    </>
+  );
+};

--- a/frontend/src/components/utils/input.tsx
+++ b/frontend/src/components/utils/input.tsx
@@ -1,10 +1,9 @@
 import RawTextField from '@mui/material/TextField';
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 interface TextFieldProps {
   hidden?: boolean;
   autoComplete?: string;
-  autoFocus?: boolean;
   color?: 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
   defaultvalue?: string;
   disabled?: boolean;
@@ -27,7 +26,6 @@ interface TextFieldProps {
 export const TextField: React.FC<TextFieldProps> = ({
   hidden = false,
   autoComplete = 'off',
-  // autoFocus = false,
   color = 'secondary',
   defaultvalue,
   disabled = false,
@@ -73,14 +71,12 @@ export const TextField: React.FC<TextFieldProps> = ({
   };
   const sxprops = {
     margin: '8px',
-    // height: height,
     width: width,
   };
   return (
     <RawTextField
       hidden={hidden}
       autoComplete={autoComplete}
-      // autoFocus={autoFocus}
       color={color}
       defaultValue={defaultvalue}
       disabled={disabled}
@@ -91,7 +87,6 @@ export const TextField: React.FC<TextFieldProps> = ({
       placeholder={placehodler}
       multiline={multiline}
       maxRows={maxRows}
-      // readOnly={readOnly}
       type={type}
       InputLabelProps={{
         shrink: isShrunk,
@@ -112,12 +107,14 @@ export const TextField: React.FC<TextFieldProps> = ({
 };
 
 interface ImageInputProps {
+  children?: React.ReactNode;
   id: string;
-  onImageChange: (image: string | undefined) => void;
+  onImageChange: (image: Blob) => void;
   maxSize?: number;
 }
 
 export const ImageInput: React.FC<ImageInputProps> = ({
+  children,
   id,
   onImageChange,
   maxSize = Infinity,
@@ -125,7 +122,6 @@ export const ImageInput: React.FC<ImageInputProps> = ({
   const onChangeFileInput = (
     event: React.ChangeEvent<HTMLInputElement>,
   ): void => {
-    // setImagePreview(undefined);
     if (event.target.files?.length === 0) {
       return;
     } else if (event.target.files?.[0] === undefined) {
@@ -136,19 +132,18 @@ export const ImageInput: React.FC<ImageInputProps> = ({
       alert('画像のサイズが大きすぎます!');
       return;
     }
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      onImageChange(e.target?.result as string);
-    };
-    reader.readAsDataURL(event.target?.files[0]);
+    onImageChange(event.target?.files?.[0]);
   };
   return (
-    <input
-      type='file'
-      accept='image/*'
-      id={id}
-      onChange={onChangeFileInput}
-      hidden={true}
-    />
+    <>
+      <input
+        type='file'
+        accept='image/*'
+        id={id}
+        onChange={onChangeFileInput}
+        hidden={true}
+      />
+      {children}
+    </>
   );
 };

--- a/frontend/src/components/utils/input.tsx
+++ b/frontend/src/components/utils/input.tsx
@@ -1,5 +1,4 @@
 import RawTextField from '@mui/material/TextField';
-import Image1 from 'next/image';
 import { useState } from 'react';
 
 interface TextFieldProps {
@@ -113,74 +112,43 @@ export const TextField: React.FC<TextFieldProps> = ({
 };
 
 interface ImageInputProps {
-  alt?: string;
-  maxwidth?: number;
   id: string;
+  onImageChange: (image: string | undefined) => void;
+  maxSize?: number;
 }
 
 export const ImageInput: React.FC<ImageInputProps> = ({
-  alt = '画像プレビュー',
-  maxwidth = 300,
   id,
+  onImageChange,
+  maxSize = Infinity,
 }) => {
-  //event handler start
-  const [imagePreview, setImagePreview] = useState<
-    string | ArrayBuffer | null | undefined
-  >(undefined);
-  const [heightPixel, setHeightPixel] = useState(0);
-  const [widthPixel, setWidthPixel] = useState(0);
   const onChangeFileInput = (
     event: React.ChangeEvent<HTMLInputElement>,
   ): void => {
-    setImagePreview(undefined);
+    // setImagePreview(undefined);
     if (event.target.files?.length === 0) {
       return;
-    }
-    if (event.target.files?.[0] === undefined) {
+    } else if (event.target.files?.[0] === undefined) {
       return;
-    }
-    if (!event.target.files?.[0].type.match('image.*')) {
+    } else if (!event.target.files?.[0].type.match('image.*')) {
+      return;
+    } else if (event.target.files?.[0].size > maxSize) {
+      alert('画像のサイズが大きすぎます!');
       return;
     }
     const reader = new FileReader();
     reader.onload = (e) => {
-      setImagePreview(e.target?.result);
-      const image = new Image();
-      image.src = e.target?.result as string;
-      image.onload = () => {
-        const originalWidth = image.width as number;
-        const originalHeight = image.height as number;
-        //画像のサイズに関する制限などはここに書けばよさそう
-        if (originalWidth > originalHeight) {
-          setWidthPixel(maxwidth);
-          setHeightPixel((maxwidth * originalHeight) / originalWidth);
-        } else {
-          setHeightPixel(maxwidth);
-          setWidthPixel((maxwidth * originalWidth) / originalHeight);
-        }
-      };
+      onImageChange(e.target?.result as string);
     };
-
     reader.readAsDataURL(event.target?.files[0]);
   };
-  //event handler end
   return (
-    <>
-      <input
-        type='file'
-        accept='image/*'
-        id={id}
-        onChange={onChangeFileInput}
-        hidden={true}
-      />
-      <output>
-        <Image1
-          src={imagePreview as string}
-          alt={alt}
-          width={widthPixel}
-          height={heightPixel}
-        />
-      </output>
-    </>
+    <input
+      type='file'
+      accept='image/*'
+      id={id}
+      onChange={onChangeFileInput}
+      hidden={true}
+    />
   );
 };

--- a/frontend/src/components/utils/input.tsx
+++ b/frontend/src/components/utils/input.tsx
@@ -1,5 +1,5 @@
 import RawTextField from '@mui/material/TextField';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 interface TextFieldProps {
   hidden?: boolean;


### PR DESCRIPTION
インプットコンポーネントをとりあえず形にはできたはず。
テキストフィールドとイメージインプットを両方いれてある
イメージインプットは強制的にhiddenしてあるためidを指定してbuttonなどから呼ぶこと限定にしてある。
maxwidthプロパティは画像を入れる箱の一辺を想定。縦または横のどちらか長い方がmaxwidthに合わせられて、もう一方の辺は元画像の縦横比を保ったまま拡大または縮小されるような挙動を示すように設計。
いまのところはサイズ上限などの処置は実装できていない。